### PR TITLE
docs: add and improve README.md for all packages

### DIFF
--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -51,7 +51,7 @@ All channels extend `ChannelAdapter` which provides:
 - **Reconnection** — exponential backoff with configurable `initialMs`, `maxMs`, `factor`, `jitter`, and `maxAttempts`
 - **Deduplication** — automatic message dedup with configurable `dedupeMaxSize` and `dedupeTtlMs`
 - **Text chunking** — `chunkText(text, maxLen)` splits long messages at newline boundaries while preserving code fences
-- **Safe disconnect** — `disconnect()` aborts the reconnect controller before closing the underlying client, preventing zombie socket races
+- **Safe disconnect** — `disconnect()` aborts the reconnect controller before closing the underlying client
 
 ```js
 import { ChannelAdapter, chunkText } from '@vox-ai-app/channels/adapter'
@@ -59,23 +59,51 @@ import { ChannelAdapter, chunkText } from '@vox-ai-app/channels/adapter'
 const chunks = chunkText(longMessage, 2000)
 ```
 
+### Reconnect config
+
+Pass `reconnect` in the channel config to tune the backoff:
+
+| Option         | Default | Description                                          |
+| -------------- | ------- | ---------------------------------------------------- |
+| `initialMs`    | `2000`  | Delay before the first reconnect attempt.            |
+| `maxMs`        | `30000` | Maximum delay cap.                                   |
+| `factor`       | `1.8`   | Exponential backoff multiplier.                      |
+| `jitter`       | `0.25`  | Random jitter fraction applied to each delay.        |
+| `maxAttempts`  | `12`    | Give up after this many consecutive failed attempts. |
+
+```js
+const channel = new TelegramChannel({
+  botToken: '...',
+  reconnect: { initialMs: 1000, maxAttempts: 5 }
+})
+```
+
 ## API
 
-Every channel implements:
+Every channel implements the following interface:
 
 ```js
 await channel.connect()
-await channel.send(peerId, text, options?)
 await channel.disconnect()
-channel.toJSON() // { id, connected }
+await channel.send(peerId, text, options?)         // send a text message
+await channel.editMessage(peerId, messageId, text) // edit a sent message (if supported)
+await channel.deleteMessage(peerId, messageId)     // delete a message (if supported)
+await channel.react(peerId, messageId, emoji)      // react to a message (if supported)
+await channel.readMessages(peerId, options?)       // read message history (if supported)
+await channel.sendTyping(peerId)                   // show typing indicator
+await channel.executeAction(action)                // dispatch a structured action object
+channel.toJSON()                                   // { id, connected }
 ```
+
+`executeAction` dispatches to the above methods based on `action.action`:
+`'send'`, `'edit'`, `'delete'`, `'react'`, `'read'`, `'typing'`.
 
 Events:
 
 ```js
 channel.on('message', ({ channel, peerId, text, timestamp, raw }) => {})
-channel.on('status', ({ channel, status }) => {})
-channel.on('error', ({ channel, error }) => {})
+channel.on('status',  ({ channel, status }) => {})  // 'connected' | 'disconnected' | 'reconnecting'
+channel.on('error',   ({ channel, error }) => {})
 ```
 
 ## License

--- a/packages/indexing/README.md
+++ b/packages/indexing/README.md
@@ -74,12 +74,12 @@ getIndexingStatus() // current status + progress
 
 ### IPC registration
 
-For Electron apps that expose indexing over IPC:
+For Electron apps that expose indexing over IPC, import from the `./ipc` sub-export and pass your app's IPC helper factories:
 
 ```js
 import { registerIndexingIpc } from '@vox-ai-app/indexing/ipc'
 
-registerIndexingIpc()
+registerIndexingIpc({ createHandler, registerHandler })
 // Registers: indexing:get-folders, indexing:add-folder, indexing:remove-folder,
 //            indexing:rebuild, indexing:get-status, indexing:pick-folder,
 //            indexing:get-indexed-children, indexing:reset-state
@@ -87,7 +87,7 @@ registerIndexingIpc()
 
 ### Process status subscription (advanced)
 
-For apps that want push-based status updates from the utility process:
+Push-based status updates are available via the `./process` sub-export:
 
 ```js
 import { setOnStatusChange } from '@vox-ai-app/indexing/process'
@@ -105,7 +105,7 @@ setOnStatusChange((status) => {
 
 ## Build
 
-Register two additional entry points in your Electron build config:
+The indexing package needs two additional Electron entry points — the utility process and the parser worker. They are resolved at runtime from the built output, so register them in your build config:
 
 ```js
 // electron.vite.config.js
@@ -123,6 +123,8 @@ export default {
   }
 }
 ```
+
+At runtime the host resolves the process entry as `out/main/indexing.process.js` (relative to `app.getAppPath()`).
 
 ## License
 

--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -1,8 +1,8 @@
 # @vox-ai-app/integrations
 
-macOS system integrations for Vox: Apple Mail, Screen control, and iMessage. Each integration ships with tool implementations and LLM tool definitions.
+System integrations for Vox: email, screen control, and messaging. Each integration exposes a **platform-agnostic API** backed by OS-specific implementations in subdirectories (e.g. `mac/`). Tool definitions are OS-independent and work unchanged across platforms.
 
-- Initial release.## [1.0.0] - 2026-03-24- `openDb` / `closeDb` lifecycle.- WAL journal mode, foreign keys, auto-schema creation.- Initial SQLite-based persistence: conversations, messages, tasks, task activity.### Added## [1.0.2] - 2026-04-01- `checkpointId` type consistency.- `getAllSettings` return type (now returns object instead of array).### Fixed- Added migration system (`src/migrations/runner.js` + `001_initial_schema.js`).- Added new exports: `./tools`, `./settings`, `./mcp-servers`, `./schedules`, `./tool-secrets`, `./patterns`, `./vectors`.- Updated exports map: all repo modules now resolve to `./src/repos/*.js`.- Moved 9 repository files from flat `src/` into `src/repos/` subdirectory.### ChangedRequires macOS. Each integration needs specific system permissions granted by the user.
+The macOS implementations ship today. Adding Windows or Linux support means providing a sibling implementation directory and re-exporting it from the existing dispatch layer — no interface changes required.
 
 ## Install
 
@@ -12,52 +12,119 @@ npm install @vox-ai-app/integrations
 
 Peer dependency: `electron >= 28`
 
+## Architecture
+
+Each integration follows this structure:
+
+```
+src/
+  mail/
+    index.js          ← platform-agnostic dispatch + input normalisation
+    def.js            ← OS-independent LLM tool definitions
+    send/
+      index.js        ← re-exports from ./mac/
+      mac/            ← macOS implementation (AppleScript/JXA)
+    read/
+      index.js
+      mac/
+    manage/
+      index.js
+      mac/
+    shared/
+      index.js
+      mac/
+  screen/
+    index.js
+    def.js
+    capture/
+      index.js
+      mac/
+    control/
+      index.js
+      mac/
+    queue.js          ← platform-agnostic session serialiser
+  imessage/
+    index.js
+    def.js
+    mac/              ← reads chat.db, AppleScript reply, gateway service
+```
+
 ## Exports
 
-| Export                                    | Contents                      |
-| ----------------------------------------- | ----------------------------- |
-| `@vox-ai-app/integrations`                | All exports                   |
-| `@vox-ai-app/integrations/defs/mail`      | Mail tool definitions         |
-| `@vox-ai-app/integrations/defs/screen`    | Screen tool definitions       |
-| `@vox-ai-app/integrations/defs/imessage`  | iMessage tool definitions     |
-| `@vox-ai-app/integrations/mail`           | Mail functions                |
-| `@vox-ai-app/integrations/screen`         | Screen capture + control      |
-| `@vox-ai-app/integrations/screen/capture` | Capture only                  |
-| `@vox-ai-app/integrations/screen/control` | Control only                  |
-| `@vox-ai-app/integrations/screen/queue`   | Session acquire/release       |
-| `@vox-ai-app/integrations/imessage`       | iMessage data, reply, service |
+| Export                                    | Contents                                   |
+| ----------------------------------------- | ------------------------------------------ |
+| `@vox-ai-app/integrations`                | All exports                                |
+| `@vox-ai-app/integrations/defs/mail`      | Mail tool definitions (OS-independent)     |
+| `@vox-ai-app/integrations/defs/screen`    | Screen tool definitions (OS-independent)   |
+| `@vox-ai-app/integrations/defs/imessage`  | iMessage tool definitions (OS-independent) |
+| `@vox-ai-app/integrations/mail`           | Mail functions                             |
+| `@vox-ai-app/integrations/screen`         | Screen capture + control                   |
+| `@vox-ai-app/integrations/screen/capture` | Capture only                               |
+| `@vox-ai-app/integrations/screen/control` | Control only                               |
+| `@vox-ai-app/integrations/screen/queue`   | Session acquire/release                    |
+| `@vox-ai-app/integrations/imessage`       | Messaging data, reply, gateway service     |
 
 ## Mail
 
-Requires **Automation permission** for Mail (System Settings → Privacy & Security → Automation).
+### Usage
 
 ```js
-import { sendEmail, readEmails, searchContacts, replyToEmail } from '@vox-ai-app/integrations/mail'
+import {
+  sendEmail,
+  readEmails,
+  getEmailBody,
+  searchContacts,
+  replyToEmail,
+  forwardEmail,
+  markEmailRead,
+  flagEmail,
+  deleteEmail,
+  moveEmail,
+  createDraft,
+  saveAttachment
+} from '@vox-ai-app/integrations/mail'
 
-const emails = await readEmails({ account: 'Work', folder: 'INBOX', limit: 20 })
+const { messages } = await readEmails({ folder: 'INBOX', limit: 20, unreadOnly: true })
 await sendEmail({ to: 'user@example.com', subject: 'Hi', body: 'Hello.' })
-await replyToEmail({ messageId: '...', body: 'Thanks!' })
+await replyToEmail({ messageId: messages[0].id, body: 'Thanks!' })
 ```
 
-Tool definitions:
+### Tool definitions
 
 ```js
 import { MAIL_TOOL_DEFINITIONS } from '@vox-ai-app/integrations/defs/mail'
 ```
 
+### Current implementation: macOS (Apple Mail via AppleScript)
+
+Requires **Automation permission** for Mail.app — System Settings → Privacy & Security → Automation.
+
 ## Screen
 
-Requires **Accessibility permission** (System Settings → Privacy & Security → Accessibility).
+### Usage
 
 ```js
 import {
   captureFullScreen,
+  captureRegion,
+  waitForScreenPermission,
   clickAt,
+  moveMouse,
   typeText,
-  getUiElements
+  keyPress,
+  scroll,
+  drag,
+  getMousePosition,
+  getUiElements,
+  clipboardRead,
+  clipboardWrite,
+  focusApp,
+  launchApp,
+  listApps
 } from '@vox-ai-app/integrations/screen'
-import { acquireScreen, releaseScreen } from '@vox-ai-app/integrations/screen/queue'
+import { acquireScreen, releaseScreen, getScreenSession } from '@vox-ai-app/integrations/screen/queue'
 
+// Serialise screen access across concurrent agent tasks
 const session = await acquireScreen()
 try {
   const img = await captureFullScreen()
@@ -68,54 +135,72 @@ try {
 }
 ```
 
-Tool definitions:
+### Tool definitions
 
 ```js
 import { SCREEN_TOOL_DEFINITIONS } from '@vox-ai-app/integrations/defs/screen'
 ```
 
-## iMessage
+### Current implementation: macOS (Accessibility API + screencapture)
 
-Requires **Full Disk Access** (System Settings → Privacy & Security → Full Disk Access).
+Requires **Accessibility permission** — System Settings → Privacy & Security → Accessibility.
 
-### Tool use (read conversations, send messages)
+## Messaging (iMessage)
+
+### Tool use — read conversations and send messages
 
 ```js
-import { listConversations, listContacts, sendReply } from '@vox-ai-app/integrations/imessage'
+import {
+  canReadDb,
+  listConversations,
+  listContacts,
+  queryNewMessages,
+  sendReply
+} from '@vox-ai-app/integrations/imessage'
 
-const conversations = listConversations()
-const contacts = listContacts()
+const conversations = await listConversations()
+const contacts = await listContacts()
 await sendReply('+15551234567', 'Hello from Vox!')
 ```
 
-### Gateway service (AI replies to incoming iMessages)
+### Gateway service — AI replies to incoming messages
 
 ```js
 import { createIMessageService } from '@vox-ai-app/integrations/imessage'
 
 const svc = createIMessageService({
   logger,
-  onTranscript: (text, handle) => {
-    /* emit to UI */
-  },
+  onTranscript: (text, handle) => { /* emit to UI */ },
   onOpenSettings: () => shell.openExternal('x-apple.systempreferences:...'),
   onMessage: async (text, handle) => {
-    // call your AI here, return the reply string
+    // return the reply string, or null to skip
     return await askAI(text)
   }
 })
 
 svc.start('my-passphrase')
-// user sends "my-passphrase\nWhat's the weather?" → AI replies back
+// anyone who texts "my-passphrase\n<question>" gets an AI reply
 ```
 
-`onMessage` must return a `Promise<string | null>`. Returning `null` skips the reply.
-
-Tool definitions:
+### Tool definitions
 
 ```js
 import { IMESSAGE_TOOL_DEFINITIONS } from '@vox-ai-app/integrations/defs/imessage'
 ```
+
+### Current implementation: macOS (chat.db + Messages AppleScript)
+
+Requires **Full Disk Access** — System Settings → Privacy & Security → Full Disk Access.
+
+## Contributing
+
+To add a Windows or Linux implementation for any integration:
+
+1. Create a sibling directory alongside `mac/` (e.g. `windows/` or `linux/`)
+2. Implement the same exported function signatures
+3. Update the dispatch `index.js` to re-export from the correct directory based on `process.platform`
+
+The tool definitions (`def.js`) and the platform-agnostic input normalisation in each top-level `index.js` require no changes.
 
 ## License
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -15,26 +15,47 @@ import { connectMcpServer, setLogger } from '@vox-ai-app/mcp'
 
 setLogger(logger)
 
+// stdio — command string is shell-parsed (env var prefixes supported)
 const { client, tools } = await connectMcpServer({
-  id: 'my-server',
-  command: 'npx',
-  args: ['-y', '@modelcontextprotocol/server-filesystem', '/home']
+  id: 'filesystem',
+  transport: 'stdio',
+  command: 'npx -y @modelcontextprotocol/server-filesystem /home'
+})
+
+// http
+const { client, tools } = await connectMcpServer({
+  id: 'my-api',
+  transport: 'http',
+  url: 'https://my-mcp-server.example.com/mcp',
+  auth_header: 'Bearer sk-...'
 })
 
 // tools is an array of { name, description, inputSchema }
 console.log(tools.map((t) => t.name))
 
-// call a tool directly
+// call a tool directly via the MCP client
 const result = await client.callTool({ name: 'read_file', arguments: { path: '/home/notes.md' } })
 ```
 
+## Server config
+
+The `server` object accepted by `connectMcpServer` and `makeTransport`:
+
+| Field         | Type      | Description                                                              |
+| ------------- | --------- | ------------------------------------------------------------------------ |
+| `id`          | `string`  | Unique identifier used for session persistence.                          |
+| `transport`   | `string`  | `'stdio'`, `'sse'`, or `'http'`.                                         |
+| `command`     | `string`  | Shell command string for stdio transport (env var prefixes are allowed). |
+| `url`         | `string`  | Server URL for SSE/HTTP transports.                                      |
+| `auth_header` | `string`  | Optional value for the `Authorization` request header.                  |
+
 ## Transport types
 
-| Type  | Config                               |
-| ----- | ------------------------------------ |
-| stdio | `{ command, args, env }`             |
-| SSE   | `{ url }` where url ends with `/sse` |
-| HTTP  | `{ url }` (streamable HTTP)          |
+| Type    | Config fields used            | Notes                                          |
+| ------- | ----------------------------- | ---------------------------------------------- |
+| `stdio` | `command` (+ optional prefix env vars) | Command is shell-parsed; env var prefixes like `KEY=val cmd arg` are supported. |
+| `sse`   | `url`, `auth_header`          | Uses SSE long-polling.                         |
+| `http`  | `url`, `auth_header`          | Streamable HTTP. Sessions are persisted.       |
 
 ## Session management
 

--- a/packages/scheduler/README.md
+++ b/packages/scheduler/README.md
@@ -1,6 +1,6 @@
 # @vox-ai-app/scheduler
 
-Cron-based job scheduler for Vox — schedule recurring agent runs, heartbeats, and timed tasks with timezone support.
+Cron-based job scheduler for Vox — schedule recurring agent runs, heartbeats, and timed tasks with full timezone support, one-time triggers, and fixed-interval repeats.
 
 ## Install
 
@@ -10,61 +10,143 @@ npm install @vox-ai-app/scheduler
 
 ## Exports
 
-| Export                       | Contents                              |
-| ---------------------------- | ------------------------------------- |
-| `@vox-ai-app/scheduler`      | All scheduler exports                 |
-| `@vox-ai-app/scheduler/cron` | Job scheduling, cancellation, listing |
+| Export                       | Contents                                                    |
+| ---------------------------- | ----------------------------------------------------------- |
+| `@vox-ai-app/scheduler`      | All scheduler exports                                       |
+| `@vox-ai-app/scheduler/cron` | `scheduleJob`, `scheduleAt`, `scheduleEvery`, and utilities |
 
 ## Usage
 
+### Recurring cron job
+
 ```js
-import { scheduleJob, cancelJob, listJobs, computeNextRun } from '@vox-ai-app/scheduler'
+import { scheduleJob, cancelJob, listJobs } from '@vox-ai-app/scheduler'
 
 const job = scheduleJob(
-  'daily-check',
-  { expr: '0 9 * * *', tz: 'America/New_York' },
-  (id, meta) => {
-    console.log(`Job ${id} fired at ${meta.firedAt}`)
+  'daily-report',
+  {
+    expr: '0 9 * * 1-5', // weekdays at 09:00
+    tz: 'America/New_York',
+    runImmediately: false,
+    timeoutMs: 30_000,
+    onError: (err) => console.error(err)
+  },
+  (id, ctx) => {
+    console.log(`Job ${id} fired at ${ctx.scheduledAt}`)
   }
 )
 
-console.log(listJobs())
-cancelJob('daily-check')
+console.log(listJobs()) // [{ id, expr, timezone, nextRun, running, state }]
+cancelJob('daily-report')
 ```
 
-Schedule persistence is handled by the app layer via `@vox-ai-app/storage/schedules`.
+### One-time trigger
+
+```js
+import { scheduleAt, parseAbsoluteTimeMs } from '@vox-ai-app/scheduler'
+
+const atMs = parseAbsoluteTimeMs('2026-12-25T09:00:00')
+
+scheduleAt('xmas-alert', { at: atMs }, (id, ctx) => {
+  console.log(`Fired once at ${ctx.scheduledAt}`)
+  // job is automatically removed after firing
+})
+```
+
+### Fixed interval
+
+```js
+import { scheduleEvery, cancelJob } from '@vox-ai-app/scheduler'
+
+scheduleEvery(
+  'heartbeat',
+  { intervalMs: 60_000, timeoutMs: 5_000 },
+  async (id, ctx) => {
+    await sendHeartbeat()
+  }
+)
+
+cancelJob('heartbeat')
+```
 
 ## API
 
-### Cron
+### `scheduleJob(id, config, handler)`
 
-| Function         | Description                                     |
-| ---------------- | ----------------------------------------------- |
-| `scheduleJob`    | Schedule a cron job with handler callback       |
-| `cancelJob`      | Cancel a job by ID                              |
-| `cancelAllJobs`  | Cancel all running jobs                         |
-| `getJob`         | Get job details by ID                           |
-| `listJobs`       | List all active jobs with next run times        |
-| `computeNextRun` | Compute the next run time for a cron expression |
+Schedule a recurring cron job. If a job with the same `id` already exists it is cancelled first.
 
-`scheduleJob` options:
+Handler signature: `(id, ctx) => void | Promise<void>`
+
+| Config option    | Type       | Description                                                    |
+| ---------------- | ---------- | -------------------------------------------------------------- |
+| `expr`           | `string`   | Cron expression (e.g. `'0 9 * * *'`, `'*/5 * * * *'`)         |
+| `tz`             | `string`   | IANA timezone name. Defaults to the system timezone.           |
+| `runImmediately` | `boolean`  | Fire the handler once immediately on registration.             |
+| `timeoutMs`      | `number`   | Abort the handler after this many ms using `AbortSignal`.      |
+| `onError`        | `function` | Called when the handler throws. Receives the `Error` instance. |
+
+Handler context object:
 
 ```js
-scheduleJob(
-  id,
-  {
-    expr: '0 9 * * 1-5',
-    tz: 'America/New_York',
-    runImmediately: false,
-    onError: (err) => {}
-  },
-  handler
-)
+{
+  scheduledAt: number,   // Unix ms timestamp of the fire time
+  expr: string,          // cron expression
+  timezone: string,      // resolved IANA timezone
+  signal?: AbortSignal   // present when timeoutMs is set
+}
 ```
 
-## Dependencies
+### `scheduleAt(id, config, handler)`
 
-- [croner](https://github.com/hexagon/croner) ^9.0.0
+Schedule a one-time trigger at an absolute timestamp. The job self-removes after firing. Returns `null` if `at` is already in the past.
+
+| Config option | Type               | Description                           |
+| ------------- | ------------------ | ------------------------------------- |
+| `at`          | `number \| string` | Unix ms timestamp or ISO date string. |
+
+### `scheduleEvery(id, config, handler)`
+
+Schedule a fixed-interval repeating job. Minimum `intervalMs` is 1 000 ms. Returns `null` for invalid intervals.
+
+| Config option | Type     | Description                                            |
+| ------------- | -------- | ------------------------------------------------------ |
+| `intervalMs`  | `number` | Milliseconds between handler calls.                    |
+| `timeoutMs`   | `number` | Abort signal timeout for each individual handler call. |
+
+### Utilities
+
+| Function                     | Description                                                                                       |
+| ---------------------------- | ------------------------------------------------------------------------------------------------- |
+| `cancelJob(id)`              | Stop and remove a job by id. Returns `true` if found, `false` otherwise.                          |
+| `cancelAllJobs()`            | Stop and remove all registered jobs.                                                              |
+| `getJob(id)`                 | Return a job descriptor or `null` if not found.                                                   |
+| `listJobs()`                 | Return all active job descriptors as an array.                                                    |
+| `computeNextRun(expr, tz)`   | Return the next fire time in ms for a cron expression without scheduling.                         |
+| `parseAbsoluteTimeMs(input)` | Parse an ISO date string or a numeric string into a Unix ms timestamp. Returns `null` on failure. |
+
+### Job descriptor shape
+
+```js
+{
+  id: string,
+  expr: string,
+  timezone: string,
+  createdAt: number,
+  nextRun: number | null,
+  running: boolean,
+  state: {
+    runCount: number,
+    lastError: Error | null,
+    lastRunAtMs: number | null
+  }
+}
+```
+
+## Notes
+
+- A minimum re-fire gap of 2 000 ms prevents accidental double-fires during DST transitions.
+- Cron expression evaluation results are LRU-cached (up to 512 entries) for performance.
+- Schedule persistence is the caller's responsibility — use [`@vox-ai-app/storage`](../storage) schedules repo.
 
 ## License
 

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -96,12 +96,52 @@ const activity = loadTaskActivity(db, 'abc-123')
 ## Settings
 
 ```js
-import { getSetting, setSetting, getAllSettings, deleteSetting } from '@vox-ai-app/storage/settings'
+import { getSetting, setSetting, getSettingJson, getAllSettings, deleteSetting } from '@vox-ai-app/storage/settings'
 
 setSetting(db, 'theme', 'dark')
-const theme = getSetting(db, 'theme')
-const all = getAllSettings(db)
+const theme = getSetting(db, 'theme')      // raw string
+const json  = getSettingJson(db, 'prefs', {}) // parsed JSON with fallback
+const all   = getAllSettings(db)           // { key: rawString, ... }
 deleteSetting(db, 'theme')
+```
+
+## MCP Servers
+
+```js
+import {
+  createMcpServer,
+  updateMcpServer,
+  deleteMcpServer,
+  getMcpServer,
+  listMcpServers
+} from '@vox-ai-app/storage/mcp-servers'
+
+const srv = createMcpServer(db, {
+  name: 'filesystem',
+  transport: 'stdio',
+  command: 'npx -y @modelcontextprotocol/server-filesystem /home',
+  isEnabled: true
+})
+
+const all = listMcpServers(db)                    // all servers
+const enabled = listMcpServers(db, true)           // enabled only
+updateMcpServer(db, srv.id, { isEnabled: false })
+deleteMcpServer(db, srv.id)
+```
+
+## Vectors
+
+Cosine-similarity vector store backed by SQLite. Intended for small local knowledge bases (< ~50 k vectors).
+
+```js
+import { vectorUpsert, vectorSearch } from '@vox-ai-app/storage/vectors'
+
+// Store an embedding (Float32Array or number[])
+vectorUpsert(db, 'knowledge', 'doc-1', embeddingValues, { path: '/docs/readme.md' })
+
+// Cosine-similarity search with optional BM25 reranking
+const results = vectorSearch(db, 'knowledge', queryEmbedding, 'search text', 10)
+// [{ id, score, metadata }]
 ```
 
 ## License

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -30,7 +30,7 @@ import {
   CopyButton,
   Drawer,
   Skeleton,
-  Toast,
+  ToastLayer, useToast,
   ExpandableMarkdown
 } from '@vox-ai-app/ui/primitives'
 ```
@@ -41,14 +41,14 @@ Feature components built from primitives.
 
 ```js
 import {
-  ChatMessage,
+  ChatMessage, ToolGroup,
   ChatComposer,
   ChatEmptyState,
-  ChatScreenMessages,
+  ChatScreenMessages, groupMessages,
   ChatSkeleton,
   ActionItem,
   ActivityListRow,
-  ActivityTimeline,
+  TimelineMarker, StepItem,
   ExplorerSidebar,
   ExplorerTile,
   VoiceOrb
@@ -66,14 +66,39 @@ import { AppShell, LeftRail, UserMenu } from '@vox-ai-app/ui/layouts'
 ### Hooks
 
 ```js
-import {} from /* hooks */ '@vox-ai-app/ui/hooks'
+import {
+  useClickOutside,       // fires handler on mousedown outside the returned ref
+  useEscapeKey,          // fires handler when the Escape key is pressed
+  useIntersectionObserver // fires callback when the returned ref enters/leaves viewport
+} from '@vox-ai-app/ui/hooks'
+```
+
+```js
+const ref = useClickOutside(() => setOpen(false))
+return <div ref={ref}>...</div>
 ```
 
 ### Utils
 
 ```js
-import { cn } from '@vox-ai-app/ui/utils'
-// cn(...classes) — merges Tailwind class names
+import {
+  cn,                // merge Tailwind class names (clsx + twMerge)
+  parseToolArgs,     // safely parse tool args from a raw JSON string or object
+  toolLabel,         // human-readable label for a tool call name
+  relativeTime,      // format ISO date as "3m ago", "2h ago"
+  elapsedLabel,      // format elapsed time as "12s", "3m 14s"
+  formatBytes,       // format byte count as "4.2 MB"
+  formatIndexedTime, // format ISO date as a short locale-aware string
+  getStatusLabel,    // map an indexing status key to a display string
+  PHASE,             // task phase constants: IDLE, SENDING, STREAMING, …
+  TERMINAL_STATUSES, // Set of statuses representing a finished task
+  RUNNING_STATUSES,  // Set of statuses representing an active task
+  TASK_STATUS_COLOR, // map of task status → CSS color token
+  TASK_STATUS_LABEL, // map of task status → display label
+  PRIMARY_ARG_KEYS,  // priority-ordered list of arg keys shown as the primary value
+  getToolSub,        // get a secondary display label for a tool call
+  getOutcomeBadge    // get badge variant + label for a task outcome
+} from '@vox-ai-app/ui/utils'
 ```
 
 ### Tokens
@@ -91,8 +116,29 @@ import { colors } from '@vox-ai-app/ui/tokens'
 
 ## All exports
 
+All primitives, composites, layouts, hooks, utilities, and tokens are re-exported from the package root:
+
 ```js
-import {} from /* everything */ '@vox-ai-app/ui'
+import {
+  // primitives
+  Drawer, ToastLayer, useToast, Skeleton, CopyButton, ExpandableMarkdown, IconButton,
+  // composites
+  ChatMessage, ToolGroup, ChatComposer, ChatEmptyState, ChatScreenMessages, groupMessages,
+  ChatSkeleton, VoiceOrb, TimelineMarker, StepItem, ActivityListRow, ActionItem,
+  ExplorerTile, ExplorerSidebar,
+  // layouts
+  AppShell, LeftRail, UserMenu,
+  // layouts
+  AppShell, LeftRail, UserMenu,
+  // hooks
+  useClickOutside, useEscapeKey, useIntersectionObserver,
+  // utils
+  cn, parseToolArgs, toolLabel, relativeTime, elapsedLabel, formatBytes,
+  formatIndexedTime, getStatusLabel, PHASE, TERMINAL_STATUSES, RUNNING_STATUSES,
+  TASK_STATUS_COLOR, TASK_STATUS_LABEL, PRIMARY_ARG_KEYS, getToolSub, getOutcomeBadge,
+  // tokens
+  colors, darkColors, getColors
+} from '@vox-ai-app/ui'
 ```
 
 ## License

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -12,12 +12,13 @@ Peer dependencies: `electron >= 28`, `@picovoice/pvrecorder-node >= 1.0.0`, `onn
 
 ## Requirements
 
-- macOS (pvrecorder + ONNX wake word models)
-- Microphone permission (requested automatically on first use)
 - ONNX models at `resources/voice/` in the app package:
   - `melspectrogram.onnx`
   - `embedding_model.onnx`
   - `computer.onnx`
+- Microphone permission — on macOS this is requested automatically via `systemPreferences.askForMediaAccess`. On other platforms the wake word worker starts without a permission prompt (OS-level mic access is assumed).
+
+The ONNX detection pipeline (`onnxruntime-web` WASM) and `pvrecorder-node` are cross-platform. The keyboard shortcut registers as `CommandOrControl+Alt+V` (`Ctrl+Alt+V` on Windows/Linux, `Cmd+Alt+V` on macOS) with `CommandOrControl+Shift+Space` as a fallback.
 
 ## Usage
 
@@ -43,7 +44,7 @@ await initVoiceService({
 await destroyVoiceService()
 ```
 
-`onActivate` handles both wake word detection and the keyboard shortcut (`Cmd+Alt+V`, falling back to `Cmd+Shift+Space`). If omitted, only the `setOnWakeWordDetected` callback fires on wake word.
+`onActivate` handles both wake word detection and the keyboard shortcut (`CommandOrControl+Alt+V`). If omitted, only the `setOnWakeWordDetected` callback fires on wake word.
 
 ## Voice Window
 


### PR DESCRIPTION
Closes #33

## What

Adds or rewrites `README.md` for all 11 packages under `packages/`:

| Package | Change |
|---|---|
| `scheduler` | Full rewrite — `scheduleJob`, `scheduleAt`, `scheduleEvery`, job descriptor shape, DST/caching notes |
| `channels` | Full rewrite — all adapter methods, reconnect config table, events |
| `integrations` | Full rewrite — reflects platform-agnostic architecture (`mac/` subdirs), contributing guide for Windows/Linux |
| `ui` | Full rewrite — all primitives, composites, layouts, hooks, utils, tokens with correct export names |
| `voice` | Full rewrite — cross-platform requirements, wake word control, worker build config |
| `mcp` | Full rewrite — server config table, all 3 transports, session management |
| `parser` | Full rewrite — `readDocumentFile`, individual parsers, supported format table |
| `indexing` | Full rewrite — runtime lifecycle, `registerIndexingIpc` signature, build config |
| `storage` | Full rewrite — all 11 sub-exports including vectors and MCP servers |
| `skills` | Full rewrite — already had a README; verified and kept as-is |
| `tools` | Unchanged — used as the template |

## Template

Used `packages/tools/README.md` as the template throughout.