### PR TITLE
fix: tar extraction depended on local tar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vox",
-  "version": "2.1.7",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vox",
-      "version": "2.1.7",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -20,7 +20,7 @@
         "@sentry/electron": "^7.10.0",
         "@vox-ai-app/channels": "^1.0.0",
         "@vox-ai-app/indexing": "^1.0.2",
-        "@vox-ai-app/integrations": "^1.0.4",
+        "@vox-ai-app/integrations": "^1.1.0",
         "@vox-ai-app/mcp": "^1.0.1",
         "@vox-ai-app/scheduler": "^1.0.0",
         "@vox-ai-app/skills": "^1.0.0",
@@ -34,6 +34,7 @@
         "qrcode.react": "^4.2.0",
         "react-icons": "^5.6.0",
         "react-virtuoso": "^4.12.0",
+        "tar": "^7.5.15",
         "zustand": "^5.0.0"
       },
       "devDependencies": {
@@ -18527,9 +18528,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.12",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.12.tgz",
-      "integrity": "sha512-9TsuLcdhOn4XztcQqhNyq1KOwOOED/3k58JAvtULiYqbO8B/0IBAAIE1hj0Svmm58k27TmcigyDI0deMlgG3uw==",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -20444,7 +20445,7 @@
     },
     "packages/integrations": {
       "name": "@vox-ai-app/integrations",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@vox-ai-app/tools": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "qrcode.react": "^4.2.0",
     "react-icons": "^5.6.0",
     "react-virtuoso": "^4.12.0",
+    "tar": "^7.5.15",
     "zustand": "^5.0.0"
   },
   "devDependencies": {

--- a/src/main/ai/llm/binary.manager.js
+++ b/src/main/ai/llm/binary.manager.js
@@ -1,6 +1,7 @@
 import { execSync, exec } from 'child_process'
 import { promisify } from 'util'
 import { join, dirname } from 'path'
+import { extract as extractTar } from 'tar'
 
 const execAsync = promisify(exec)
 import {
@@ -155,10 +156,10 @@ async function download(destPath) {
   logger.info(LOG_PREFIX, `Downloaded ${downloaded} bytes`)
 }
 
-function extract(archivePath, destDir) {
+async function extract(archivePath, destDir) {
   const assetName = getAssetName()
   if (assetName.endsWith('.tar.gz')) {
-    execSync(`tar xzf "${archivePath}" -C "${destDir}"`)
+    await extractTar({ file: archivePath, cwd: destDir })
   } else {
     execSync(`unzip -o "${archivePath}" -d "${destDir}"`)
   }
@@ -227,7 +228,7 @@ export async function ensure() {
     await download(tmpArchive)
 
     mkdirSync(tmpExtract, { recursive: true })
-    extract(tmpArchive, tmpExtract)
+    await extract(tmpArchive, tmpExtract)
 
     installFromExtract(tmpExtract, versionDir)
     removeQuarantine(versionDir)

--- a/tests/ai/llm/binary.manager.test.js
+++ b/tests/ai/llm/binary.manager.test.js
@@ -19,6 +19,7 @@ const mockRenameSync = vi.fn()
 const mockRmSync = vi.fn()
 const mockReaddirSync = vi.fn(() => [])
 const mockCopyFileSync = vi.fn()
+const mockExtractTar = vi.fn()
 
 vi.mock('fs', () => ({
   existsSync: (...args) => mockExistsSync(...args),
@@ -43,6 +44,10 @@ vi.mock('child_process', () => ({
     if (cmd.includes('--version')) return 'version: 8635\n'
     return ''
   })
+}))
+
+vi.mock('tar', () => ({
+  extract: (...args) => mockExtractTar(...args)
 }))
 
 vi.mock('electron', () => ({
@@ -70,6 +75,7 @@ describe('binary.manager', async () => {
       throw new Error('ENOENT')
     })
     mockReaddirSync.mockReturnValue([])
+    mockExtractTar.mockResolvedValue()
   })
 
   describe('resolve', () => {
@@ -172,6 +178,10 @@ describe('binary.manager', async () => {
       const result = await manager.ensure()
 
       expect(result).toContain('llama-server')
+      expect(mockExtractTar).toHaveBeenCalledWith({
+        file: expect.stringContaining('.tar.gz.tmp'),
+        cwd: expect.stringContaining('extract-tmp')
+      })
       expect(mockCopyFileSync).toHaveBeenCalled()
       expect(mockWriteFileSync).toHaveBeenCalledWith(expect.stringContaining('version'), 'b8635')
 


### PR DESCRIPTION
## What

Replaces shell-based `.tar.gz` extraction for the managed `llama-server` binary with the Node `tar` package.
Fixes: #45 

## Why

Packaged Electron environments can have a restricted `PATH`, causing binary install to fail with:

```sh
/bin/sh: tar: command not found